### PR TITLE
Backend: Add Group API (creation, members, invitation, leave)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ import { PrismaClient } from "@prisma/client";
 import testRoutes from "./routes/test.js";
 import authRouter from "./routes/auth.routes.js";
 import userRouter from "./routes/user.routes.js";
+import groupRouter from "./routes/group.routes.js";
 
 const app = express();
 const prisma = new PrismaClient();
@@ -17,6 +18,8 @@ app.use("/api", testRoutes);
 app.use("/auth", authRouter);
 
 app.use("/users", userRouter);
+
+app.use("/groups", groupRouter);
 
 // 서버 테스트용 엔드포인트
 app.get("/", (req, res) => {

--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -1,0 +1,126 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+// 1) 그룹 생성
+export const createGroup = async (req, res) => {
+  try {
+    const { name } = req.body;
+    const uid = req.user.uid;
+
+    if (!name) return res.status(400).json({ error: "Group name required" });
+
+    // owner userId 찾기
+    const owner = await prisma.user.findUnique({
+      where: { uid },
+    });
+
+    const group = await prisma.group.create({
+      data: {
+        name,
+        ownerId: owner.id,
+        members: {
+          create: {
+            userId: owner.id,
+            role: "owner",
+          },
+        },
+      },
+    });
+
+    return res.json({ group });
+  } catch (err) {
+    console.error("createGroup error:", err);
+    return res.status(500).json({ error: "Failed to create group" });
+  }
+};
+
+// 2) 그룹 상세 조회
+export const getGroupDetail = async (req, res) => {
+  try {
+    const groupId = Number(req.params.groupId);
+
+    const group = await prisma.group.findUnique({
+      where: { id: groupId },
+      include: {
+        owner: true,
+        members: {
+          include: {
+            user: true,
+          },
+        },
+        tasks: true,
+      },
+    });
+
+    if (!group) return res.status(404).json({ error: "Group not found" });
+
+    return res.json({ group });
+  } catch (err) {
+    console.error("getGroupDetail error:", err);
+    return res.status(500).json({ error: "Failed to load group" });
+  }
+};
+
+// 3) 그룹 멤버 조회
+export const getGroupMembers = async (req, res) => {
+  try {
+    const groupId = Number(req.params.groupId);
+
+    const members = await prisma.groupMember.findMany({
+      where: { groupId },
+      include: { user: true },
+    });
+
+    return res.json({ members });
+  } catch (err) {
+    console.error("getGroupMembers error:", err);
+    return res.status(500).json({ error: "Failed to load members" });
+  }
+};
+
+// 4) 그룹 초대 생성
+export const createInvitation = async (req, res) => {
+  try {
+    const groupId = Number(req.params.groupId);
+    const { email } = req.body;
+
+    if (!email) return res.status(400).json({ error: "Email required" });
+
+    const token = crypto.randomUUID();
+
+    const invitation = await prisma.invitation.create({
+      data: {
+        groupId,
+        email,
+        token,
+      },
+    });
+
+    return res.json({ invitation });
+  } catch (err) {
+    console.error("createInvitation error:", err);
+    return res.status(500).json({ error: "Failed to create invitation" });
+  }
+};
+
+// 5) 그룹 탈퇴
+export const leaveGroup = async (req, res) => {
+  try {
+    const groupId = Number(req.params.groupId);
+    const uid = req.user.uid;
+
+    const user = await prisma.user.findUnique({ where: { uid } });
+
+    await prisma.groupMember.deleteMany({
+      where: {
+        groupId,
+        userId: user.id,
+      },
+    });
+
+    return res.json({ message: "Left group successfully" });
+  } catch (err) {
+    console.error("leaveGroup error:", err);
+    return res.status(500).json({ error: "Failed to leave group" });
+  }
+};

--- a/backend/src/routes/group.routes.js
+++ b/backend/src/routes/group.routes.js
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import {
+  createGroup,
+  getGroupDetail,
+  getGroupMembers,
+  createInvitation,
+  leaveGroup,
+} from "../controllers/group.controller.js";
+
+import { verifyToken } from "../middlewares/auth.js";
+
+const router = Router();
+
+// 그룹 생성
+router.post("/", verifyToken, createGroup);
+
+// 그룹 상세
+router.get("/:groupId", verifyToken, getGroupDetail);
+
+// 그룹 멤버
+router.get("/:groupId/members", verifyToken, getGroupMembers);
+
+// 초대 생성
+router.post("/:groupId/invite", verifyToken, createInvitation);
+
+// 그룹 나가기
+router.delete("/:groupId/leave", verifyToken, leaveGroup);
+
+export default router;


### PR DESCRIPTION
### 추가한 기능
- POST /groups
- GET /groups/:groupId
- GET /groups/:groupId/members
- POST /groups/:groupId/invite
- DELETE /groups/:groupId/leave

### 내부 로직
- Firebase token validation(verifyToken) 연동
- Prisma group, groupMember, invitation 관계 처리