### PR TITLE
Backend: Add Task API (create/update/group-tasks/today-tasks)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ import testRoutes from "./routes/test.js";
 import authRouter from "./routes/auth.routes.js";
 import userRouter from "./routes/user.routes.js";
 import groupRouter from "./routes/group.routes.js";
+import taskRouter from "./routes/task.routes.js";
 
 const app = express();
 const prisma = new PrismaClient();
@@ -14,12 +15,10 @@ app.use(express.json());
 
 // 라우터
 app.use("/api", testRoutes);
-
 app.use("/auth", authRouter);
-
 app.use("/users", userRouter);
-
 app.use("/groups", groupRouter);
+app.use("/", taskRouter);
 
 // 서버 테스트용 엔드포인트
 app.get("/", (req, res) => {

--- a/backend/src/routes/task.routes.js
+++ b/backend/src/routes/task.routes.js
@@ -1,0 +1,25 @@
+import { Router } from "express";
+import {
+  createTask,
+  updateTask,
+  getGroupTasks,
+  getTodayTasks,
+} from "../controllers/task.controller.js";
+
+import { verifyToken } from "../middlewares/auth.js";
+
+const router = Router();
+
+// 할 일 생성
+router.post("/groups/:groupId/tasks", verifyToken, createTask);
+
+// 특정 그룹의 모든 Task
+router.get("/groups/:groupId/tasks", verifyToken, getGroupTasks);
+
+// Task 업데이트(isDone 변경)
+router.patch("/tasks/:taskId", verifyToken, updateTask);
+
+// 오늘의 Task
+router.get("/tasks/today", verifyToken, getTodayTasks);
+
+export default router;


### PR DESCRIPTION
### 추가된 기능
- POST /groups/:groupId/tasks (할 일 생성)
- PATCH /tasks/:taskId (할 일 상태 변경)
- GET /groups/:groupId/tasks (그룹의 모든 할 일 조회)
- GET /tasks/today (오늘의 할 일 조회)

### 내부 구현
- Prisma Task 모델 연동
- Firebase 인증 미들웨어 사용
- 그룹/유저/테스크 관계 처리